### PR TITLE
fix: strip quotes from inputs and lightning: prefix

### DIFF
--- a/src/components/Faucet.tsx
+++ b/src/components/Faucet.tsx
@@ -59,7 +59,9 @@ export function Faucet() {
       const howMuchSats = parseInt(
         formData.get("how_much")?.toString() ?? "1000000"
       );
-      const toAddress = formData.get("address")?.toString() ?? "tb1q...";
+      let toAddress = formData.get("address")?.toString() ?? "tb1q...";
+      // Strip surrounding quotation marks if they exist
+      toAddress = toAddress.replace(/^"|"$/g, '').trim();
 
       const res = await fetch(`${FAUCET_API_URL}/api/onchain`, {
         method: "POST",

--- a/src/components/LnFaucet.tsx
+++ b/src/components/LnFaucet.tsx
@@ -52,11 +52,19 @@ function Pop(props: any) {
 export function LnFaucet() {
   const [sendResult, { Form }] = createRouteAction(
     async (formData: FormData) => {
-      const bolt11 = formData.get("bolt11")?.toString();
+      let bolt11 = formData.get("bolt11")?.toString();
 
       if (!bolt11) {
         throw new Error("No bolt11 provided");
       } else {
+        // Strip surrounding quotation marks if they exist
+        bolt11 = bolt11.replace(/^"|"$/g, '').trim();
+
+        // Remove "lightning:" prefix if it exists
+        if (bolt11.startsWith("lightning:")) {
+          bolt11 = bolt11.substring(10);
+        }
+
         // const result = await payInvoice(bolt11);
         const res = await fetch(`${FAUCET_API_URL}/api/lightning`, {
           method: "POST",


### PR DESCRIPTION
two minor improvements for convenience:
- when pasting a bolt11 invoice with a `lightning:` prefix, the faucet fails to pay the invoice so this logic just strips the prefix if detected
- in both the invoice and the onchain address fields, strip out any surrounding quotes