### PR TITLE
Add a section for receiving a lightning channel

### DIFF
--- a/src/components/LnChannel.tsx
+++ b/src/components/LnChannel.tsx
@@ -1,0 +1,190 @@
+import { createSignal, Match, Switch } from "solid-js";
+import { createRouteAction } from "solid-start";
+
+const FAUCET_API_URL = import.meta.env.VITE_FAUCET_API;
+
+const SIMPLE_BUTTON =
+  "mt-4 px-4 py-2 rounded-xl text-xl font-semibold bg-black text-white border border-white";
+
+function Pop(props: any) {
+  return (
+    <div class="rounded-xl p-4 w-full flex flex-col items-center gap-2 bg-[rgba(0,0,0,0.5)] drop-shadow-blue-glow">
+      {/* {JSON.stringify(props, null, 2)} */}
+      <Switch>
+        <Match when={props.result}>
+          <p>Opened the channel, here's the transaction id</p>
+          <pre class="text-sm font-mono">{props.result?.txid}</pre>
+          <a href={`https://mutinynet.com/tx/${props.result?.txid}`}>
+            View on mempool.space
+          </a>
+          <button
+            class={SIMPLE_BUTTON}
+            onClick={() => window.location.reload()}
+          >
+            Start Over
+          </button>
+        </Match>
+        <Match when={props.error}>
+          <p>Something went wrong</p>
+          <code>{props.error.message}</code>
+          <button
+            class={SIMPLE_BUTTON}
+            onClick={() => window.location.reload()}
+          >
+            Try again
+          </button>
+        </Match>
+        <Match when={true}>
+          <p>You probably screwed this up didn't you?</p>
+          <p>
+            (Make sure you're using a signet address btw, and don't ask for more
+            than 1BTC)
+          </p>
+          <button
+            class={SIMPLE_BUTTON}
+            onClick={() => window.location.reload()}
+          >
+            Try again
+          </button>
+        </Match>
+      </Switch>
+    </div>
+  );
+}
+
+export function LnChannel() {
+  const [sendResult, { Form }] = createRouteAction(
+    async (formData: FormData) => {
+      const connectionString = formData.get("connectionString")?.toString();
+      const [pubkey, host] = connectionString?.split("@") || [];
+
+      if (!pubkey || !host) {
+        throw new Error("Invalid connection string");
+      }
+
+      const capacity = parseInt(formData.get("capacity")?.toString() || "", 10);
+      if (Number.isNaN(capacity)) {
+        throw new Error("Invalid capacity");
+      }
+
+      const pushPercentage = parseInt(
+        formData.get("pushPercentage")?.toString() || "",
+        10
+      );
+      if (Number.isNaN(pushPercentage)) {
+        throw new Error("Invalid push percentage");
+      }
+      const pushAmount = Math.round(capacity / 100) * pushPercentage;
+
+      const res = await fetch(`${FAUCET_API_URL}/api/channel`, {
+        method: "POST",
+        body: JSON.stringify({
+          push_amount: pushAmount,
+          capacity,
+          pubkey,
+          host,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error(await res.text());
+      } else {
+        return res.json();
+      }
+    }
+  );
+
+  const [capacity, setCapacity] = createSignal("100000");
+  const [pushPercentage, setPushPercentage] = createSignal("50");
+
+  return (
+    <Switch>
+      <Match when={sendResult.result || sendResult.error}>
+        <Pop result={sendResult.result} error={sendResult.error} />
+      </Match>
+      <Match when={true}>
+        <Form class="rounded-xl p-4 flex flex-col gap-2 bg-[rgba(0,0,0,0.5)] w-full drop-shadow-blue-glow">
+          <label for="capacity">Channel capacity? (sats)</label>
+          <input
+            type="number"
+            name="capacity"
+            placeholder="sats"
+            value={capacity()}
+            onInput={(e) => setCapacity(e.currentTarget.value)}
+            max="10000001"
+          />
+          <div class="flex gap-2 -mt-2 mb-2">
+            <button
+              type="button"
+              onClick={() => setCapacity("10000000")}
+              class={SIMPLE_BUTTON}
+            >
+              10M
+            </button>
+            <button
+              type="button"
+              onClick={() => setCapacity("1000000")}
+              class={SIMPLE_BUTTON}
+            >
+              1M
+            </button>
+            <button
+              type="button"
+              onClick={() => setCapacity("100000")}
+              class={SIMPLE_BUTTON}
+            >
+              100K
+            </button>
+          </div>
+          <label for="pushPercentage">Amount to push? (percentage)</label>
+          <input
+            type="number"
+            name="pushPercentage"
+            placeholder="50"
+            value={pushPercentage()}
+            onInput={(e) => setPushPercentage(e.currentTarget.value)}
+            max="100"
+          />
+          <div class="flex gap-2 -mt-2 mb-2">
+            <button
+              type="button"
+              onClick={() => setPushPercentage("0")}
+              class={SIMPLE_BUTTON}
+            >
+              0%
+            </button>
+            <button
+              type="button"
+              onClick={() => setPushPercentage("50")}
+              class={SIMPLE_BUTTON}
+            >
+              50%
+            </button>
+            <button
+              type="button"
+              onClick={() => setPushPercentage("100")}
+              class={SIMPLE_BUTTON}
+            >
+              100%
+            </button>
+          </div>
+          <label for="address">Connection string</label>
+          <input
+            type="text"
+            name="connectionString"
+            placeholder="pubkey@host:port"
+          />
+          <input
+            type="submit"
+            disabled={sendResult.pending}
+            value={sendResult.pending ? "..." : "Gimme a lightning channel"}
+            class="mt-4 p-4 rounded-xl text-xl font-semibold bg-[#1EA67F] text-white disabled:bg-gray-500"
+          />
+        </Form>
+      </Match>
+    </Switch>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { Faucet } from "~/components/Faucet";
+import { LnChannel } from "~/components/LnChannel";
 import { LnFaucet } from "~/components/LnFaucet";
 import { NWC } from "~/components/NWC";
 
@@ -10,6 +11,7 @@ export default function Home() {
       </h1>
       <Faucet />
       <LnFaucet />
+      <LnChannel />
       <NWC />
       <div class="border border-white/50 rounded-xl p-4 w-full gap-2 flex flex-col">
         <h1 class="font-bold text-xl font-mono">Join the mutinynet</h1>


### PR DESCRIPTION
### What This Does

Adds a section for having a lightning channel opened to your node from the faucet node. Has inputs for the channel amount (same amounts and limit as on chain payment) and for what percentage you want pushed to you, to allow you to make inbound only / outbound only / balanced channels (defaults to 50% push.)

Requires https://github.com/MutinyWallet/mutinynet-faucet-rs/pull/3 for the API endpoint.

## Screenshots

### The form

<img width="400" alt="Screenshot 2023-09-08 at 3 14 33 PM" src="https://github.com/MutinyWallet/mutinynet-faucet/assets/649992/9cdd78b5-2398-49dc-bdd2-b1d72d89527b">


### Error

<img width="400" alt="Screenshot 2023-09-08 at 3 13 20 PM" src="https://github.com/MutinyWallet/mutinynet-faucet/assets/649992/507bfb01-5d6b-4c60-8953-6fd02efde796">

### Success
<img width="400" alt="Screenshot 2023-09-08 at 3 13 35 PM" src="https://github.com/MutinyWallet/mutinynet-faucet/assets/649992/efe981f5-46d5-4403-8e15-8f43e129dbfe">
