### PR TITLE
Add a Send to Arkade faucet option

### DIFF
--- a/src/components/Arkade.tsx
+++ b/src/components/Arkade.tsx
@@ -1,0 +1,65 @@
+import { Match, Switch, createSignal } from "solid-js";
+import { createRouteAction } from "solid-start";
+import { api } from "~/api/client";
+
+const SIMPLE_BUTTON =
+  "mt-4 px-4 py-2 rounded-xl text-xl font-semibold bg-black text-white border border-white";
+
+function Result(props: { result: any; error: any }) {
+  return (
+    <div class="rounded-xl p-4 flex flex-col items-center gap-2 bg-[rgba(0,0,0,0.5)] drop-shadow-blue-glow">
+      <Switch>
+        <Match when={props.result?.txid}>
+          <p>Sent {props.result?.sats} sats to Arkade</p>
+          <pre class="text-sm font-mono whitespace-pre-line break-all">{props.result?.address}</pre>
+          <a href={`https://explorer.mutinynet.arkade.sh/tx/${props.result?.txid}`}>View on Arkade explorer</a>
+          <button class={SIMPLE_BUTTON} onClick={() => window.location.reload()}>Start Over</button>
+        </Match>
+        <Match when={props.error}>
+          <p>Something went wrong</p>
+          <code>{props.error.message}</code>
+          <button class={SIMPLE_BUTTON} onClick={() => window.location.reload()}>Try again</button>
+        </Match>
+      </Switch>
+    </div>
+  );
+}
+
+export function Arkade() {
+  const [amount, setAmount] = createSignal("50000");
+  const [sendResult, { Form }] = createRouteAction(async (formData: FormData) => {
+    const sats = parseInt(formData.get("how_much")?.toString() ?? "50000");
+    let address = (formData.get("address")?.toString() ?? "").replace(/^"|"$/g, "").trim();
+
+    const res = await api.post("api/arkade", { address, sats });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text.startsWith("<!DOCTYPE html>") ? "Rate limit exceeded" : text);
+    }
+    const json = await res.json();
+    return { txid: json.txid, sats, address };
+  });
+
+  return (
+    <div class="border border-white/50 rounded-xl p-4 w-full gap-2 flex flex-col">
+      <h2 class="font-bold text-xl font-mono">Send to Arkade</h2>
+      <Switch>
+        <Match when={sendResult.result || sendResult.error}>
+          <Result result={sendResult.result} error={sendResult.error} />
+        </Match>
+        <Match when={true}>
+          <Form class="rounded-xl p-4 flex flex-col gap-2 bg-[rgba(0,0,0,0.5)] w-full drop-shadow-blue-glow">
+            <label for="how_much">How much? (sats)</label>
+            <input type="number" name="how_much" placeholder="sats" value={amount()}
+              onInput={(e) => setAmount(e.currentTarget.value)} />
+            <label for="address">Arkade address</label>
+            <input type="text" name="address" placeholder="tark1..." />
+            <input type="submit" disabled={sendResult.pending}
+              value={sendResult.pending ? "..." : "Send to Arkade"}
+              class="mt-4 p-4 rounded-xl text-xl font-semibold bg-[#1EA67F] text-white disabled:bg-gray-500" />
+          </Form>
+        </Match>
+      </Switch>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { LimitProgress } from "~/components/LimitProgress";
 import { LnChannel } from "~/components/LnChannel";
 import { LnFaucet } from "~/components/LnFaucet";
 import { NWC } from "~/components/NWC";
+import { Arkade } from "~/components/Arkade";
 import {createSignal, Match, onMount, Show, Switch} from "solid-js";
 import {isAuthed, setToken, token} from "~/stores/auth";
 import {AuthButton} from "~/components/AuthButton";
@@ -61,6 +62,7 @@ export default function Home() {
                 <LnFaucet />
                 <LnChannel />
                 <NWC />
+                <Arkade />
             </Match>
             <Match when={true}>
                 <div class="border border-white/50 rounded-xl p-4 w-full gap-2 flex flex-col items-center">


### PR DESCRIPTION
Adds a "Send to Arkade" tab to the faucet, alongside the existing on-chain and Lightning options. Users paste a `tark1…` address, the frontend POSTs `{address, sats}` to the same faucet backend everything else goes through, and the backend hands the request off to a small dispenser daemon on the internal network.

The frontend change is deliberately tiny: `src/components/Arkade.tsx` calls `api.post("api/arkade", …)` just like `Faucet.tsx` calls `api/onchain`. No new env var, no direct-to-daemon fetch from the browser, no `authHeader` export — the credential model stays single-origin. Rate-limiting, ban logic, premium exemptions all come from the backend's existing middleware since `/api/arkade` is authenticated the same way as the other paid routes.

The backend and infra halves are proposed in companion PRs:

- MutinyWallet/mutinynet-faucet-rs#13 — the `POST /api/arkade` handler that runs the usual auth/rate-limit checks and forwards to the daemon.
- MutinyWallet/mutiny-net#8 — the compose service running the daemon.

The dispenser itself lives in its own repo, [Kukks/arkade-faucet-daemon](https://github.com/Kukks/arkade-faucet-daemon), published as `ghcr.io/kukks/arkade-faucet-daemon`. It's a small Node service that holds an Arkade wallet (mutinynet, testnet derivation), exposes `POST /send` on the internal network only, and auto-tops-up by calling the faucet's own `/api/onchain` when its spendable balance drops below `MIN_BALANCE`. Wallet + contract state persist to SQLite via Node's built-in `node:sqlite`, so restarts don't lose sync state. Requires Node 24 (for stable `node:sqlite`).

Bit of history if you're wondering about the shape: an earlier revision of this branch had the daemon living inside this repo under `arkade-daemon/` and the browser calling it directly with the faucet credential — which meant the faucet token had to fly to a second origin. That was wrong; this rewrite puts the daemon behind the backend where it belongs, one auth boundary, single-origin credential model. The three-repo split is the price of keeping the daemon's release cadence tied to `@arkade-os/sdk` rather than to either the frontend or `faucet-rs`.

Happy to fold the endpoint name, tab label, or destination-explorer URL to whatever fits — none of it is load-bearing.